### PR TITLE
feat(shear code requirements): add punching shear capacity calculation

### DIFF
--- a/lib/design_codes/aci_318_19/rc/footings/punching_shear_capacity.rb
+++ b/lib/design_codes/aci_318_19/rc/footings/punching_shear_capacity.rb
@@ -1,0 +1,83 @@
+require 'errors/design_codes/unrecognized_value_error'
+require 'design_codes/utils/code_requirement'
+require 'design_codes/schemas/rc/footings/punching_shear_capacity_schema'
+
+module DesignCodes
+  module ACI31819
+    module RC
+      module Footings
+        class PunchingShearCapacity
+          COLUMN_LOCATION_FACTORS = {
+            interior: 40,
+            border: 30,
+            corner: 20
+          }.freeze
+
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::Footings::PunchingShearCapacitySchema
+
+          # ACI 318-19 22.6.5.2
+          def call
+            [
+              basic_shear_capacity,
+              shear_capacity_modified_by_column_size,
+              shear_capacity_modified_by_column_location
+            ].min
+          end
+
+          private
+
+          def basic_shear_capacity
+            @basic_shear_capacity ||= 0.33 * Math.sqrt(design_compression_strength) *
+                                      light_concrete_modification_factor *
+                                      critical_section_perimeter *
+                                      effective_height *
+                                      size_effect_factor
+          end
+
+          def shear_capacity_modified_by_column_size
+            @shear_capacity_modified_by_column_size ||= 0.17 * Math.sqrt(design_compression_strength) *
+                                                        light_concrete_modification_factor *
+                                                        critical_section_perimeter *
+                                                        effective_height *
+                                                        (1 + 2 / column_aspect_ratio) *
+                                                        size_effect_factor
+          end
+
+          def shear_capacity_modified_by_column_location
+            @shear_capacity_modified_by_column_location ||= 0.083 * Math.sqrt(design_compression_strength) *
+                                                            light_concrete_modification_factor *
+                                                            critical_section_perimeter *
+                                                            effective_height *
+                                                            column_location_factor *
+                                                            size_effect_factor
+          end
+
+          def column_aspect_ratio
+            @column_aspect_ratio ||= column_sizes.max / column_sizes.min
+          end
+
+          def column_sizes
+            @column_sizes ||= [column_section_width.to_f, column_section_height.to_f]
+          end
+
+          def column_location_factor
+            unless COLUMN_LOCATION_FACTORS.keys.include?(column_location)
+              raise DesignCodes::UnrecognizedValueError.new('column_location', column_location)
+            end
+
+            @column_location_factor ||= COLUMN_LOCATION_FACTORS[column_location].to_f *
+                                        effective_height / critical_section_perimeter + 2
+          end
+
+          def size_effect_factor
+            @size_effect_factor ||= [
+              1.0,
+              Math.sqrt(2 / (1 + 0.004 * effective_height))
+            ].min
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_codes/nsr_10/rc/footings/punching_shear_capacity.rb
+++ b/lib/design_codes/nsr_10/rc/footings/punching_shear_capacity.rb
@@ -1,0 +1,73 @@
+require 'errors/design_codes/unrecognized_value_error'
+require 'design_codes/utils/code_requirement'
+require 'design_codes/schemas/rc/footings/punching_shear_capacity_schema'
+
+module DesignCodes
+  module NSR10
+    module RC
+      module Footings
+        class PunchingShearCapacity
+          COLUMN_LOCATION_FACTORS = {
+            interior: 40,
+            border: 30,
+            corner: 20
+          }.freeze
+
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::Footings::PunchingShearCapacitySchema
+
+          # NSR-10 C.11.11.2.1
+          def call
+            [
+              basic_shear_capacity,
+              shear_capacity_modified_by_column_size,
+              shear_capacity_modified_by_column_location
+            ].min
+          end
+
+          private
+
+          def basic_shear_capacity
+            @basic_shear_capacity ||= 0.33 * Math.sqrt(design_compression_strength) *
+                                      light_concrete_modification_factor *
+                                      critical_section_perimeter *
+                                      effective_height
+          end
+
+          def shear_capacity_modified_by_column_size
+            @shear_capacity_modified_by_column_size ||= 0.17 * Math.sqrt(design_compression_strength) *
+                                                        light_concrete_modification_factor *
+                                                        critical_section_perimeter *
+                                                        effective_height *
+                                                        (1 + 2 / column_aspect_ratio)
+          end
+
+          def shear_capacity_modified_by_column_location
+            @shear_capacity_modified_by_column_location ||= 0.083 * Math.sqrt(design_compression_strength) *
+                                                            light_concrete_modification_factor *
+                                                            critical_section_perimeter *
+                                                            effective_height *
+                                                            column_location_factor
+          end
+
+          def column_aspect_ratio
+            @column_aspect_ratio ||= column_sizes.max / column_sizes.min
+          end
+
+          def column_sizes
+            @column_sizes ||= [column_section_width.to_f, column_section_height.to_f]
+          end
+
+          def column_location_factor
+            unless COLUMN_LOCATION_FACTORS.keys.include?(column_location)
+              raise DesignCodes::UnrecognizedValueError.new('column_location', column_location)
+            end
+
+            @column_location_factor ||= COLUMN_LOCATION_FACTORS[column_location].to_f *
+                                        effective_height / critical_section_perimeter + 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/design_codes/schemas/rc/footings/punching_shear_capacity_schema.rb
+++ b/lib/design_codes/schemas/rc/footings/punching_shear_capacity_schema.rb
@@ -1,0 +1,25 @@
+require 'design_codes/utils/schema_definition'
+
+module DesignCodes
+  module Schemas
+    module RC
+      module Footings
+        class PunchingShearCapacitySchema
+          include DesignCodes::Utils::SchemaDefinition
+
+          required_params %i[
+            column_section_width
+            column_section_height
+            design_compression_strength
+            critical_section_perimeter
+            effective_height
+            light_concrete_modification_factor
+            column_location
+          ]
+
+          optional_params []
+        end
+      end
+    end
+  end
+end

--- a/lib/design_codes/utils/code_requirement.rb
+++ b/lib/design_codes/utils/code_requirement.rb
@@ -17,6 +17,9 @@ module DesignCodes
         def call(params = {})
           schema_klass.validate!(params)
           sanitized_params = schema_klass.structurize(params)
+          sanitized_params.members.each do |param_name|
+            define_method(param_name) { sanitized_params[param_name] }
+          end
 
           obj = new(sanitized_params)
           obj.call

--- a/lib/errors/design_codes/unrecognized_value_error.rb
+++ b/lib/errors/design_codes/unrecognized_value_error.rb
@@ -1,0 +1,7 @@
+module DesignCodes
+  class UnrecognizedValueError < StandardError
+    def initialize(name, value)
+      super("#{value} for #{name} param couldnt be recognized")
+    end
+  end
+end

--- a/spec/design_codes/aci_318_19/rc/footings/punching_shear_capacity_spec.rb
+++ b/spec/design_codes/aci_318_19/rc/footings/punching_shear_capacity_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'design_codes/aci_318_19/rc/footings/punching_shear_capacity'
+require 'errors/design_codes/missing_param_error'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe DesignCodes::ACI31819::RC::Footings::PunchingShearCapacity do
+  describe '.call' do
+    subject(:result) do
+      described_class.call(
+        column_section_width:,
+        column_section_height:,
+        design_compression_strength:,
+        critical_section_perimeter:,
+        effective_height:,
+        light_concrete_modification_factor:,
+        column_location:
+      )
+    end
+
+    let(:column_section_width) { 500 }
+    let(:column_section_height) { 500 }
+    let(:design_compression_strength) { 28 }
+    let(:critical_section_perimeter) { 1480 }
+    let(:effective_height) { 120 }
+    let(:light_concrete_modification_factor) { 1 }
+    let(:column_location) { :interior }
+
+    it 'returns the shear capacity for punching failure' do
+      expect(result.round(2)).to eq(310_124.39)
+    end
+
+    describe 'when column is located in the footing corner' do
+      let(:column_location) { :corner }
+
+      it 'returns the shear capacity for punching failure' do
+        expect(result.round(2)).to eq(282_490.04)
+      end
+    end
+
+    describe 'when column has a very high aspect ratio' do
+      let(:column_section_width) { 700 }
+      let(:column_section_height) { 200 }
+
+      it 'returns the shear capacity for punching failure' do
+        expect(result.round(2)).to eq(251_053.07)
+      end
+    end
+
+    describe 'when effective height is too high' do
+      let(:effective_height) { 350 }
+
+      it 'returns the shear capacity for punching failure' do
+        expect(result.round(2)).to eq(825_718.65)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/design_codes/nsr_10/rc/footings/punching_shear_capacity_spec.rb
+++ b/spec/design_codes/nsr_10/rc/footings/punching_shear_capacity_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'design_codes/nsr_10/rc/footings/punching_shear_capacity'
+require 'errors/design_codes/missing_param_error'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe DesignCodes::NSR10::RC::Footings::PunchingShearCapacity do
+  describe '.call' do
+    subject(:result) do
+      described_class.call(
+        column_section_width:,
+        column_section_height:,
+        design_compression_strength:,
+        critical_section_perimeter:,
+        effective_height:,
+        light_concrete_modification_factor:,
+        column_location:
+      )
+    end
+
+    let(:column_section_width) { 500 }
+    let(:column_section_height) { 500 }
+    let(:design_compression_strength) { 28 }
+    let(:critical_section_perimeter) { 1480 }
+    let(:effective_height) { 120 }
+    let(:light_concrete_modification_factor) { 1 }
+    let(:column_location) { :interior }
+
+    it 'returns the shear capacity for punching failure' do
+      expect(result.round(2)).to eq(310_124.39)
+    end
+
+    describe 'when column is located in the footing corner' do
+      let(:column_location) { :corner }
+
+      it 'returns the shear capacity for punching failure' do
+        expect(result.round(2)).to eq(282_490.04)
+      end
+    end
+
+    describe 'when column has a very high aspect ratio' do
+      let(:column_section_width) { 700 }
+      let(:column_section_height) { 200 }
+
+      it 'returns the shear capacity for punching failure' do
+        expect(result.round(2)).to eq(251_053.07)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/design_codes/schemas/rc/footings/punching_shear_capacity_schema_spec.rb
+++ b/spec/design_codes/schemas/rc/footings/punching_shear_capacity_schema_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'design_codes/schemas/rc/footings/punching_shear_capacity_schema'
+require 'errors/design_codes/missing_param_error'
+
+RSpec.describe DesignCodes::Schemas::RC::Footings::PunchingShearCapacitySchema do
+  describe '.validate!' do
+    subject(:result) { described_class.validate!(params) }
+
+    let(:params) do
+      {
+        column_section_width: 300,
+        column_section_height: 500,
+        design_compression_strength: 28,
+        critical_section_perimeter: 3200,
+        effective_height: 240,
+        light_concrete_modification_factor: 1,
+        column_location: :interior
+      }
+    end
+
+    it 'returns true' do
+      expect(result).to eq(true)
+    end
+
+    describe 'when required param is missing' do
+      let(:params) { {} }
+
+      it 'raises an error' do
+        expect { result }.to raise_error(DesignCodes::MissingParamError)
+      end
+    end
+  end
+
+  describe '.structurize' do
+    subject(:result) { described_class.structurize(params) }
+
+    let(:params) do
+      {
+        column_section_width: 300,
+        column_section_height: 500,
+        design_compression_strength: 28,
+        critical_section_perimeter: 3200,
+        effective_height: 240,
+        light_concrete_modification_factor: 1,
+        column_location: :interior
+      }
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns a struct with the required param' do
+      expect(result.members).to match_array(
+        %i[
+          column_section_width
+          column_section_height
+          design_compression_strength
+          critical_section_perimeter
+          effective_height
+          light_concrete_modification_factor
+          column_location
+          schema
+        ]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end


### PR DESCRIPTION
Closes #22

This PR adds a couple new code requirement abstractions to calculate the punching shear capacity of footings as per NSR-10 and ACI 318-19.

There are some testing scenarios here:
[punching_shear.xlsx](https://github.com/PradaIng/structuraid-core/files/10949894/punching_shear.xlsx)
