### PR TITLE
Feat/capacity reduction factors

### DIFF
--- a/lib/structuraid_core/design_codes/aci_318_19/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/aci_318_19/rc/reduction_factor.rb
@@ -1,0 +1,88 @@
+module StructuraidCore
+  module DesignCodes
+    module ACI31819
+      module RC
+        class ReductionFactor
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::ReductionFactorSchema
+
+          CONTROL_STRENGTH_CASES = %i[
+            compression_controlled
+            tension_controlled
+            transition_controlled
+            crushing_controlled
+            shear_nonseismic_controller
+            torsion_controlled
+            corbel_bracket_controlled
+            strud_and_tie_controlled
+          ].freeze
+
+          MAX_STRAIN_BEFORE_TRANSITION = 0.002 # 21.2.2.1 - 21.2.2.2
+          MIN_STRAIN_AFTER_TRANSITION = 0.005 # 21.2.2.1 - 21.2.2.2
+
+          CODE_REFERENCE = 'ACI 318-19 21.2'.freeze
+
+          # ACI 318-19 21.2
+          def call
+            unless CONTROL_STRENGTH_CASES.include?(strength_controlling_behaviour)
+              raise UnrecognizedValueError.new(strength_controlling_behaviour, :strength_controlling_behaviour)
+            end
+
+            # Table 21.2.1 (a) (h)
+            return tension_controlled_factor if strength_controlling_behaviour == :tension_controlled
+            # Table 21.2.1 (a)
+            return compression_controlled_factor if strength_controlling_behaviour == :compression_controlled
+            # Table 21.2.1 (d)
+            return crushing_controlled_factor if strength_controlling_behaviour == :crushing_controlled
+            # Table 21.2.1 (b) (c) (f) (g)
+            if %i[
+              shear_nonseismic_controller
+              torsion_controlled
+              corbel_bracket_controlled
+              strud_and_tie_controlled
+            ].include?(strength_controlling_behaviour)
+              return shear_nonseismic_controller_factor
+            end
+
+            # Table 21.2.1 (a)
+            transition_controlled_factor
+          end
+
+          private
+
+          def shear_nonseismic_controller_factor
+            0.75
+          end
+
+          def crushing_controlled_factor
+            0.65
+          end
+
+          def tension_controlled_factor
+            0.90
+          end
+
+          def compression_controlled_factor
+            return 0.75 if is_coil_rebar
+
+            0.65
+          end
+
+          def transition_controlled_factor
+            raise MissingParamError, :strain unless strain
+
+            transition_controlled_by_strain
+          end
+
+          def transition_controlled_by_strain
+            return compression_controlled_factor if strain < MAX_STRAIN_BEFORE_TRANSITION
+            return tension_controlled_factor if strain > MIN_STRAIN_AFTER_TRANSITION
+
+            transition_rate = is_coil_rebar ? 50 : 250 / 3
+            compression_controlled_factor + (strain - MAX_STRAIN_BEFORE_TRANSITION) * transition_rate
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/structuraid_core/design_codes/aci_318_19/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/aci_318_19/rc/reduction_factor.rb
@@ -11,7 +11,7 @@ module StructuraidCore
             tension_controlled
             transition_controlled
             crushing_controlled
-            shear_nonseismic_controller
+            shear_nonseismic_controlled
             torsion_controlled
             corbel_bracket_controlled
             strud_and_tie_controlled
@@ -36,12 +36,12 @@ module StructuraidCore
             return crushing_controlled_factor if strength_controlling_behaviour == :crushing_controlled
             # Table 21.2.1 (b) (c) (f) (g)
             if %i[
-              shear_nonseismic_controller
+              shear_nonseismic_controlled
               torsion_controlled
               corbel_bracket_controlled
               strud_and_tie_controlled
             ].include?(strength_controlling_behaviour)
-              return shear_nonseismic_controller_factor
+              return shear_nonseismic_controlled_factor
             end
 
             # Table 21.2.1 (a)
@@ -50,7 +50,7 @@ module StructuraidCore
 
           private
 
-          def shear_nonseismic_controller_factor
+          def shear_nonseismic_controlled_factor
             0.75
           end
 

--- a/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
@@ -10,6 +10,9 @@ module StructuraidCore
             compression_controlled
             tension_controlled
             transition_controlled
+            crushing_controlled
+            shear_nonseismic_controller
+            strud_and_tie_controlled
           ].freeze
 
           MAX_STRAIN_BEFORE_TRANSITION = 0.002
@@ -24,11 +27,23 @@ module StructuraidCore
 
             return tension_controlled_factor if strength_controlling_behaviour == :tension_controlled
             return compression_controlled_factor if strength_controlling_behaviour == :compression_controlled
+            return crushing_controlled_factor if strength_controlling_behaviour == :crushing_controlled
+            if %i[shear_nonseismic_controller strud_and_tie_controlled].include?(strength_controlling_behaviour)
+              return shear_nonseismic_controller_factor
+            end
 
             transition_controlled_factor
           end
 
           private
+
+          def shear_nonseismic_controller_factor
+            0.75
+          end
+
+          def crushing_controlled_factor
+            0.65
+          end
 
           def tension_controlled_factor
             0.90

--- a/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
@@ -12,6 +12,8 @@ module StructuraidCore
             transition_controlled
             crushing_controlled
             shear_nonseismic_controller
+            torsion_controlled
+            corbel_bracket_controlled
             strud_and_tie_controlled
           ].freeze
 
@@ -28,7 +30,12 @@ module StructuraidCore
             return tension_controlled_factor if strength_controlling_behaviour == :tension_controlled
             return compression_controlled_factor if strength_controlling_behaviour == :compression_controlled
             return crushing_controlled_factor if strength_controlling_behaviour == :crushing_controlled
-            if %i[shear_nonseismic_controller strud_and_tie_controlled].include?(strength_controlling_behaviour)
+            if %i[
+              shear_nonseismic_controller
+              torsion_controlled
+              corbel_bracket_controlled
+              strud_and_tie_controlled
+            ].include?(strength_controlling_behaviour)
               return shear_nonseismic_controller_factor
             end
 

--- a/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
@@ -11,7 +11,7 @@ module StructuraidCore
             tension_controlled
             transition_controlled
             crushing_controlled
-            shear_nonseismic_controller
+            shear_nonseismic_controlled
             torsion_controlled
             corbel_bracket_controlled
             strud_and_tie_controlled
@@ -31,12 +31,12 @@ module StructuraidCore
             return compression_controlled_factor if strength_controlling_behaviour == :compression_controlled
             return crushing_controlled_factor if strength_controlling_behaviour == :crushing_controlled
             if %i[
-              shear_nonseismic_controller
+              shear_nonseismic_controlled
               torsion_controlled
               corbel_bracket_controlled
               strud_and_tie_controlled
             ].include?(strength_controlling_behaviour)
-              return shear_nonseismic_controller_factor
+              return shear_nonseismic_controlled_factor
             end
 
             transition_controlled_factor
@@ -44,7 +44,7 @@ module StructuraidCore
 
           private
 
-          def shear_nonseismic_controller_factor
+          def shear_nonseismic_controlled_factor
             0.75
           end
 

--- a/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/reduction_factor.rb
@@ -1,0 +1,60 @@
+module StructuraidCore
+  module DesignCodes
+    module NSR10
+      module RC
+        class ReductionFactor
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::ReductionFactorSchema
+
+          CONTROL_STRENGTH_CASES = %i[
+            compression_controlled
+            tension_controlled
+            transition_controlled
+          ].freeze
+
+          MAX_STRAIN_BEFORE_TRANSITION = 0.002
+          MIN_STRAIN_AFTER_TRANSITION = 0.005
+
+          CODE_REFERENCE = 'NSR-10 C.9.3.2'.freeze
+
+          def call
+            unless CONTROL_STRENGTH_CASES.include?(strength_controlling_behaviour)
+              raise UnrecognizedValueError.new(strength_controlling_behaviour, :strength_controlling_behaviour)
+            end
+
+            return tension_controlled_factor if strength_controlling_behaviour == :tension_controlled
+            return compression_controlled_factor if strength_controlling_behaviour == :compression_controlled
+
+            transition_controlled_factor
+          end
+
+          private
+
+          def tension_controlled_factor
+            0.90
+          end
+
+          def compression_controlled_factor
+            return 0.75 if is_coil_rebar
+
+            0.65
+          end
+
+          def transition_controlled_factor
+            raise MissingParamError, :strain unless strain
+
+            transition_controlled_by_strain
+          end
+
+          def transition_controlled_by_strain
+            return compression_controlled_factor if strain < MAX_STRAIN_BEFORE_TRANSITION
+            return tension_controlled_factor if strain > MIN_STRAIN_AFTER_TRANSITION
+
+            transition_rate = is_coil_rebar ? 50 : 250 / 3
+            compression_controlled_factor + (strain - MAX_STRAIN_BEFORE_TRANSITION) * transition_rate
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/structuraid_core/design_codes/schemas/rc/reduction_factor_schema.rb
+++ b/lib/structuraid_core/design_codes/schemas/rc/reduction_factor_schema.rb
@@ -1,0 +1,17 @@
+module StructuraidCore
+  module DesignCodes
+    module Schemas
+      module RC
+        class ReductionFactorSchema
+          include DesignCodes::Utils::SchemaDefinition
+
+          required_params %i[strength_controlling_behaviour]
+          optional_params %i[
+            strain
+            is_coil_rebar
+          ]
+        end
+      end
+    end
+  end
+end

--- a/spec/structuraid_core/design_codes/aci_318_19/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/aci_318_19/rc/reduction_factor_spec.rb
@@ -1,0 +1,216 @@
+require 'spec_helper'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe StructuraidCore::DesignCodes::ACI31819::RC::ReductionFactor do
+  let(:max_strain_before_transition) do
+    StructuraidCore::DesignCodes::ACI31819::RC::ReductionFactor::MAX_STRAIN_BEFORE_TRANSITION
+  end
+  let(:min_strain_after_transition) do
+    StructuraidCore::DesignCodes::ACI31819::RC::ReductionFactor::MIN_STRAIN_AFTER_TRANSITION
+  end
+
+  describe '.call' do
+    describe 'when strength controlling behaviour has a wrong value' do
+      subject(:result) do
+        described_class.call(
+          strength_controlling_behaviour:
+        )
+      end
+
+      let(:strength_controlling_behaviour) { :wron_control_value }
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::UnrecognizedValueError)
+      end
+    end
+
+    describe 'when strength controlling is tension_controlled' do
+      subject(:result) do
+        described_class.call(
+          strength_controlling_behaviour:
+        )
+      end
+
+      let(:strength_controlling_behaviour) { :tension_controlled }
+
+      it 'returns the right reduction factor' do
+        expect(result).to eq(0.90)
+      end
+    end
+
+    describe 'when strength controlling is compression_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      describe 'when reinforcement is provided by steel coils' do
+        let(:params) do
+          {
+            strength_controlling_behaviour: :compression_controlled,
+            is_coil_rebar: true
+          }
+        end
+
+        it 'returns the right reduction factor' do
+          expect(result).to eq(0.75)
+        end
+      end
+
+      describe 'when reinforcement is provided by other steel rebar' do
+        let(:params) do
+          {
+            strength_controlling_behaviour: :compression_controlled
+          }
+        end
+
+        it 'returns the right reduction factor' do
+          expect(result).to eq(0.65)
+        end
+      end
+    end
+
+    describe 'when strength controlling is shear_nonseismic_controller || strud_and_tie_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      let(:params) do
+        {
+          strength_controlling_behaviour: %i[
+            shear_nonseismic_controller
+            torsion_controlled
+            corbel_bracket_controlled
+            strud_and_tie_controlled
+          ].sample
+        }
+      end
+
+      it 'returns the right reduction factor' do
+        expect(result).to eq(0.75)
+      end
+    end
+
+    describe 'when strength controlling is transition_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      describe 'when reinforcement is provided by steel coils' do
+        describe 'when no strain is provided' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true
+            }
+          end
+
+          it 'raises an error' do
+            expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+          end
+        end
+
+        describe 'when strain is a value in (0.001...max_strain_before_transition)' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: (0.001...max_strain_before_transition).step(0.0001).to_a.sample
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.75)
+          end
+        end
+
+        describe 'when strain is a value prominent than min_strain_after_transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: min_strain_after_transition + 0.001
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.90)
+          end
+        end
+
+        describe 'when strain is in the middle of the transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: (min_strain_after_transition + max_strain_before_transition) / 2
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result.round(3)).to eq(((0.75 + 0.90) / 2).round(3))
+          end
+        end
+      end
+
+      describe 'when reinforcement is provided by other steel rebar' do
+        describe 'when no strain is provided' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled
+            }
+          end
+
+          it 'raises an error' do
+            expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+          end
+        end
+
+        describe 'when strain is a value in (0.001...max_strain_before_transition)' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: (0.001...max_strain_before_transition).step(0.0001).to_a.sample
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.65)
+          end
+        end
+
+        describe 'when strain is a value prominent than min_strain_after_transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: min_strain_after_transition + 0.001
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.90)
+          end
+        end
+
+        describe 'when strain is in the middle of the transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: (min_strain_after_transition + max_strain_before_transition) / 2
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result.round(3)).to eq(((0.65 + 0.90) / 2).round(3))
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/aci_318_19/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/aci_318_19/rc/reduction_factor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe StructuraidCore::DesignCodes::ACI31819::RC::ReductionFactor do
       end
     end
 
-    describe 'when strength controlling is shear_nonseismic_controller || strud_and_tie_controlled' do
+    describe 'when strength controlling is shear_nonseismic_controlled || strud_and_tie_controlled' do
       subject(:result) do
         described_class.call(
           params
@@ -81,7 +81,7 @@ RSpec.describe StructuraidCore::DesignCodes::ACI31819::RC::ReductionFactor do
       let(:params) do
         {
           strength_controlling_behaviour: %i[
-            shear_nonseismic_controller
+            shear_nonseismic_controlled
             torsion_controlled
             corbel_bracket_controlled
             strud_and_tie_controlled

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 # rubocop:disable RSpec/FilePath
 RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
   let(:max_strain_before_transition) { StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MAX_STRAIN_BEFORE_TRANSITION }
+  let(:min_strain_after_transition) { StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MIN_STRAIN_AFTER_TRANSITION }
+
   describe '.call' do
     describe 'when strength controlling behaviour has a wrong value' do
       subject(:result) do
@@ -95,8 +97,22 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
             }
           end
 
-          it 'raises an error' do
+          it 'returns the right reduction factor' do
             expect(result).to eq(0.75)
+          end
+        end
+
+        describe 'when strain is a value prominent than min_strain_after_transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: min_strain_after_transition + 0.001
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.90)
           end
         end
       end
@@ -122,8 +138,21 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
             }
           end
 
-          it 'raises an error' do
+          it 'returns the right reduction factor' do
             expect(result).to eq(0.65)
+          end
+        end
+
+        describe 'when strain is a value prominent than min_strain_after_transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: min_strain_after_transition + 0.001
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result).to eq(0.90)
           end
         end
       end

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
             expect(result).to eq(0.90)
           end
         end
+
+        describe 'when strain is in the middle of the transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: (min_strain_after_transition + max_strain_before_transition) / 2
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result.round(3)).to eq(((0.75 + 0.90) / 2).round(3))
+          end
+        end
       end
 
       describe 'when reinforcement is provided by other steel rebar' do
@@ -153,6 +167,19 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
 
           it 'returns the right reduction factor' do
             expect(result).to eq(0.90)
+          end
+        end
+
+        describe 'when strain is in the middle of the transition' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: (min_strain_after_transition + max_strain_before_transition) / 2
+            }
+          end
+
+          it 'returns the right reduction factor' do
+            expect(result.round(3)).to eq(((0.65 + 0.90) / 2).round(3))
           end
         end
       end

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
+  let(:max_strain_before_transition) { StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MAX_STRAIN_BEFORE_TRANSITION }
   describe '.call' do
     describe 'when strength controlling behaviour has a wrong value' do
       subject(:result) do
@@ -84,6 +85,20 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
             expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
           end
         end
+
+        describe 'when strain is a value in (0.001...max_strain_before_transition)' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true,
+              strain: (0.001...max_strain_before_transition).step(0.0001).to_a.sample
+            }
+          end
+
+          it 'raises an error' do
+            expect(result).to eq(0.75)
+          end
+        end
       end
 
       describe 'when reinforcement is provided by other steel rebar' do
@@ -96,6 +111,19 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
 
           it 'raises an error' do
             expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+          end
+        end
+
+        describe 'when strain is a value in (0.001...max_strain_before_transition)' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              strain: (0.001...max_strain_before_transition).step(0.0001).to_a.sample
+            }
+          end
+
+          it 'raises an error' do
+            expect(result).to eq(0.65)
           end
         end
       end

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
       end
     end
 
-    describe 'when strength controlling is shear_nonseismic_controller || strud_and_tie_controlled' do
+    describe 'when strength controlling is shear_nonseismic_controlled || strud_and_tie_controlled' do
       subject(:result) do
         described_class.call(
           params
@@ -81,7 +81,7 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
       let(:params) do
         {
           strength_controlling_behaviour: %i[
-            shear_nonseismic_controller
+            shear_nonseismic_controlled
             torsion_controlled
             corbel_bracket_controlled
             strud_and_tie_controlled

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
+  describe '.call' do
+    describe 'when strength controlling behaviour has a wrong value' do
+      subject(:result) do
+        described_class.call(
+          strength_controlling_behaviour:
+        )
+      end
+
+      let(:strength_controlling_behaviour) { :wron_control_value }
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::UnrecognizedValueError)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -30,6 +30,39 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
         expect(result).to eq(0.90)
       end
     end
+
+    describe 'when strength controlling is compression_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      describe 'when reinforcement is provided by steel coils' do
+        let(:params) do
+          {
+            strength_controlling_behaviour: :compression_controlled,
+            is_coil_rebar: true
+          }
+        end
+
+        it 'returns the right reduction factor' do
+          expect(result).to eq(0.75)
+        end
+      end
+
+      describe 'when reinforcement is provided by other steel rebar' do
+        let(:params) do
+          {
+            strength_controlling_behaviour: :compression_controlled
+          }
+        end
+
+        it 'returns the right reduction factor' do
+          expect(result).to eq(0.65)
+        end
+      end
+    end
   end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
         expect { result }.to raise_error(StructuraidCore::DesignCodes::UnrecognizedValueError)
       end
     end
+
+    describe 'when strength controlling is tension_controlled' do
+      subject(:result) do
+        described_class.call(
+          strength_controlling_behaviour:
+        )
+      end
+
+      let(:strength_controlling_behaviour) { :tension_controlled }
+
+      it 'returns the right reduction factor' do
+        expect(result).to eq(0.90)
+      end
+    end
   end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
-  let(:max_strain_before_transition) { StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MAX_STRAIN_BEFORE_TRANSITION }
-  let(:min_strain_after_transition) { StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MIN_STRAIN_AFTER_TRANSITION }
+  let(:max_strain_before_transition) do
+    StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MAX_STRAIN_BEFORE_TRANSITION
+  end
+  let(:min_strain_after_transition) do
+    StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor::MIN_STRAIN_AFTER_TRANSITION
+  end
 
   describe '.call' do
     describe 'when strength controlling behaviour has a wrong value' do

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -63,6 +63,43 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
         end
       end
     end
+
+    describe 'when strength controlling is transition_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      describe 'when reinforcement is provided by steel coils' do
+        describe 'when no strain is provided' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled,
+              is_coil_rebar: true
+            }
+          end
+
+          it 'raises an error' do
+            expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+          end
+        end
+      end
+
+      describe 'when reinforcement is provided by other steel rebar' do
+        describe 'when no strain is provided' do
+          let(:params) do
+            {
+              strength_controlling_behaviour: :transition_controlled
+            }
+          end
+
+          it 'raises an error' do
+            expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+          end
+        end
+      end
+    end
   end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -80,7 +80,12 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
 
       let(:params) do
         {
-          strength_controlling_behaviour: %i[shear_nonseismic_controller strud_and_tie_controlled].sample
+          strength_controlling_behaviour: %i[
+            shear_nonseismic_controller
+            torsion_controlled
+            corbel_bracket_controlled
+            strud_and_tie_controlled
+          ].sample
         }
       end
 

--- a/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/reduction_factor_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::ReductionFactor do
       end
     end
 
+    describe 'when strength controlling is shear_nonseismic_controller || strud_and_tie_controlled' do
+      subject(:result) do
+        described_class.call(
+          params
+        )
+      end
+
+      let(:params) do
+        {
+          strength_controlling_behaviour: %i[shear_nonseismic_controller strud_and_tie_controlled].sample
+        }
+      end
+
+      it 'returns the right reduction factor' do
+        expect(result).to eq(0.75)
+      end
+    end
+
     describe 'when strength controlling is transition_controlled' do
       subject(:result) do
         described_class.call(

--- a/spec/structuraid_core/design_codes/schemas/rc/reduction_factor_schema_spec.rb
+++ b/spec/structuraid_core/design_codes/schemas/rc/reduction_factor_schema_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe StructuraidCore::DesignCodes::Schemas::RC::ReductionFactorSchema do
+  describe '.validate!' do
+    subject(:result) { described_class.validate!(params) }
+
+    let(:params) do
+      {
+        strength_controlling_behaviour: :compression_controlled
+      }
+    end
+
+    it 'returns true' do
+      expect(result).to eq(true)
+    end
+
+    describe 'when required param is missing' do
+      let(:params) { {} }
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+      end
+    end
+  end
+
+  describe '.structurize' do
+    subject(:result) { described_class.structurize(params) }
+
+    let(:params) do
+      {
+        strength_controlling_behaviour: :compression_controlled
+      }
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns a struct with the required param' do
+      expect(result.members).to match_array(
+        %i[
+          strength_controlling_behaviour
+          strain
+          is_coil_rebar
+          schema
+        ]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end


### PR DESCRIPTION
Closes #48 

This PR adds the following reduction factors, required by NSR-10 C.9.3.2 and ACI 318-19 21.2 

<img width="771" alt="image" src="https://user-images.githubusercontent.com/26731448/229621567-a9a1bdc6-1440-4a1b-bdd2-d7f5c96d72eb.png">

For long rebar, ACI and NSR define a transition-controlled zone between compression-controlled and tension-controlled zones in order to compute a reduction factor

<img width="785" alt="image" src="https://user-images.githubusercontent.com/26731448/229624402-d3eca509-71c7-48f9-a931-ddfa0072f57e.png">

