### PR TITLE
Feat/concrete cover

### DIFF
--- a/lib/structuraid_core/design_codes/aci_318_19/rc/minimum_steel_cover.rb
+++ b/lib/structuraid_core/design_codes/aci_318_19/rc/minimum_steel_cover.rb
@@ -1,0 +1,69 @@
+module StructuraidCore
+  module DesignCodes
+    module ACI31819
+      module RC
+        class MinimumSteelCover
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::MinimumSteelCoverSchema
+
+          STRUCTURAL_ELEMENTS = %i[
+            slab
+            wall
+            joist
+            beam
+            column
+            tensor_joint
+            pedestal
+          ].freeze
+
+          CODE_REFERENCE = 'ACI 318-19 21.5.1.3.1'.freeze
+
+          def call
+            compute_cover
+          end
+
+          private
+
+          # Table 20.5.1.3.1
+          def compute_cover
+            return 75 if concrete_casting_against_soil
+            return expossed_to_environment_or_soil if !concrete_casting_against_soil && environment_exposure
+            return 50 unless structural_element
+
+            non_expossed_to_environment_or_soil
+          end
+
+          def expossed_to_environment_or_soil
+            return 40 if maximum_rebar_diameter&.<= 16
+
+            50
+          end
+
+          def non_expossed_to_environment_or_soil
+            unless STRUCTURAL_ELEMENTS.include?(structural_element)
+              raise UnrecognizedValueError.new(structural_element, :structural_element)
+            end
+
+            if %i[slab wall joist].include?(structural_element)
+              slab_wall_joist_minimum_cover
+            elsif %i[beam column tensor_joint pedestal].include?(structural_element)
+              40
+            end
+          end
+
+          def slab_wall_joist_minimum_cover
+            return 20 if maximum_rebar_diameter&.<= 36
+
+            40
+          end
+
+          def shell_minimum_cover
+            return 13 if maximum_rebar_diameter&.<= 16
+
+            20
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover.rb
@@ -1,0 +1,71 @@
+module StructuraidCore
+  module DesignCodes
+    module NSR10
+      module RC
+        class MinimumSteelCoverSchema
+          include DesignCodes::Utils::CodeRequirement
+          use_schema DesignCodes::Schemas::RC::MinimumSteelCoverSchema
+
+          CONCRETE_CASTING_OR_EXPOSISION_CASES = %w[
+            c.7.7.1.a
+            c.7.7.1.b
+            c.7.7.1.c
+          ].freeze
+
+          STRUCTURAL_ELEMENTS = %i[
+            slab
+            wall
+            joist
+            beam
+            column
+            shell
+          ].freeze
+
+          CODE_REFERENCE = 'NSR-10 C.7.7.1'.freeze
+
+          def call
+            unless CONCRETE_CASTING_OR_EXPOSISION_CASES.include?(concrete_casting_or_exposision_case)
+              raise UnrecognizedValueError.new(concrete_casting_or_exposision_case, :concrete_casting_or_exposision_case)
+            end
+
+            compute_cover
+          end
+
+          private
+
+          def compute_cover
+            return 0.075 if concrete_casting_or_exposision_case == 'c.7.7.1.a'
+            return expossed_to_environment_or_soil if  concrete_casting_or_exposision_case == 'c.7.7.1.b'
+            return 0.050 unless maximum_rebar_diameter && structural_element
+
+            non_expossed_to_environment_or_soil
+          end
+
+          def expossed_to_environment_or_soil
+            return 0.050 if maximum_rebar_diameter <= 0.016
+
+            0.040
+          end
+
+          def non_expossed_to_environment_or_soil
+            unless STRUCTURAL_ELEMENTS.include?(structural_element)
+              raise UnrecognizedValueError.new(structural_element, :structural_element)
+            end
+
+            if %i[slab wall joist].include?(structural_element)
+              return 0.020 if maximum_rebar_diameter <= 0.036
+
+              0.040
+            elsif structural_element == :shell
+              return 0.013 if maximum_rebar_diameter <= 0.016
+
+              0.020
+            end
+
+            0.040
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover.rb
+++ b/lib/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover.rb
@@ -2,15 +2,9 @@ module StructuraidCore
   module DesignCodes
     module NSR10
       module RC
-        class MinimumSteelCoverSchema
+        class MinimumSteelCover
           include DesignCodes::Utils::CodeRequirement
           use_schema DesignCodes::Schemas::RC::MinimumSteelCoverSchema
-
-          CONCRETE_CASTING_OR_EXPOSISION_CASES = %w[
-            c.7.7.1.a
-            c.7.7.1.b
-            c.7.7.1.c
-          ].freeze
 
           STRUCTURAL_ELEMENTS = %i[
             slab
@@ -19,50 +13,56 @@ module StructuraidCore
             beam
             column
             shell
+            thin_shell
           ].freeze
 
           CODE_REFERENCE = 'NSR-10 C.7.7.1'.freeze
 
           def call
-            unless CONCRETE_CASTING_OR_EXPOSISION_CASES.include?(concrete_casting_or_exposision_case)
-              raise UnrecognizedValueError.new(concrete_casting_or_exposision_case, :concrete_casting_or_exposision_case)
-            end
-
             compute_cover
           end
 
           private
 
           def compute_cover
-            return 0.075 if concrete_casting_or_exposision_case == 'c.7.7.1.a'
-            return expossed_to_environment_or_soil if  concrete_casting_or_exposision_case == 'c.7.7.1.b'
-            return 0.050 unless maximum_rebar_diameter && structural_element
+            return 75 if concrete_casting_against_soil # c.7.7.1.a
+            return expossed_to_environment_or_soil if !concrete_casting_against_soil && environment_exposure # c.7.7.1.b
+            return 50 unless structural_element
 
             non_expossed_to_environment_or_soil
           end
 
           def expossed_to_environment_or_soil
-            return 0.050 if maximum_rebar_diameter <= 0.016
+            return 40 if maximum_rebar_diameter&.<= 16
 
-            0.040
+            50
           end
 
+          # c.7.7.1.c
           def non_expossed_to_environment_or_soil
             unless STRUCTURAL_ELEMENTS.include?(structural_element)
               raise UnrecognizedValueError.new(structural_element, :structural_element)
             end
 
             if %i[slab wall joist].include?(structural_element)
-              return 0.020 if maximum_rebar_diameter <= 0.036
-
-              0.040
-            elsif structural_element == :shell
-              return 0.013 if maximum_rebar_diameter <= 0.016
-
-              0.020
+              slab_wall_joist_minimum_cover
+            elsif %i[beam column].include?(structural_element)
+              40
+            elsif %i[shell thin_shell].include?(structural_element)
+              shell_minimum_cover
             end
+          end
 
-            0.040
+          def slab_wall_joist_minimum_cover
+            return 20 if maximum_rebar_diameter&.<= 36
+
+            40
+          end
+
+          def shell_minimum_cover
+            return 13 if maximum_rebar_diameter&.<= 16
+
+            20
           end
         end
       end

--- a/lib/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema.rb
+++ b/lib/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema.rb
@@ -5,7 +5,10 @@ module StructuraidCore
         class MinimumSteelCoverSchema
           include DesignCodes::Utils::SchemaDefinition
 
-          required_params %i[concrete_casting_or_exposision_case]
+          required_params %i[
+            concrete_casting_against_soil
+            environment_exposure
+          ]
           optional_params %i[
             maximum_rebar_diameter
             structural_element

--- a/lib/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema.rb
+++ b/lib/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema.rb
@@ -1,0 +1,17 @@
+module StructuraidCore
+  module DesignCodes
+    module Schemas
+      module RC
+        class MinimumSteelCoverSchema
+          include DesignCodes::Utils::SchemaDefinition
+
+          required_params %i[concrete_casting_or_exposision_case]
+          optional_params %i[
+            maximum_rebar_diameter
+            structural_element
+          ]
+        end
+      end
+    end
+  end
+end

--- a/spec/structuraid_core/design_codes/aci_318_19/rc/minimum_steel_cover_spec.rb
+++ b/spec/structuraid_core/design_codes/aci_318_19/rc/minimum_steel_cover_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe StructuraidCore::DesignCodes::ACI31819::RC::MinimumSteelCover do
+  describe '.call' do
+    subject(:result) { described_class.call(params) }
+
+    describe 'when concrete casting or exposision case not passed' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: nil,
+          environment_exposure: nil,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+      end
+    end
+
+    describe 'when concrete_casting_against_soil is true' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: true,
+          environment_exposure: false,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(75)
+      end
+    end
+
+    describe 'when environment_exposure is true' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: false,
+          environment_exposure: true,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(50)
+      end
+
+      describe 'when environment_exposure is and maximum_rebar_diameter is greater than 16mm' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: true,
+            structural_element: described_class::STRUCTURAL_ELEMENTS.sample,
+            maximum_rebar_diameter: 17
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(50)
+        end
+      end
+
+      describe 'when environment_exposure is and maximum_rebar_diameter is less than 16mm' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: true,
+            structural_element: described_class::STRUCTURAL_ELEMENTS.sample,
+            maximum_rebar_diameter: (1..16).to_a.sample
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(40)
+        end
+      end
+    end
+
+    describe 'when environment_exposure is false and concrete_casting_against_soil is false' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: false,
+          environment_exposure: false,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(50)
+      end
+
+      describe 'when structural_element is one of [slab wall joist]' do
+        describe 'when maximum_rebar_diameter is nil' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: nil
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(40)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter is greater than 36' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: 37
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(40)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter less than 36' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: (1..36).to_a.sample
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(20)
+          end
+        end
+      end
+
+      describe 'when structural_element is one of [beam column tensor_joint pedestal]' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: false,
+            structural_element: %i[beam column tensor_joint pedestal].sample,
+            maximum_rebar_diameter: nil
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(40)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover_spec.rb
+++ b/spec/structuraid_core/design_codes/nsr_10/rc/minimum_steel_cover_spec.rb
@@ -1,0 +1,208 @@
+require 'spec_helper'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe StructuraidCore::DesignCodes::NSR10::RC::MinimumSteelCover do
+  describe '.call' do
+    subject(:result) { described_class.call(params) }
+
+    describe 'when concrete casting or exposision case not passed' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: nil,
+          environment_exposure: nil,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+      end
+    end
+
+    describe 'when concrete_casting_against_soil is true' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: true,
+          environment_exposure: false,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(75)
+      end
+    end
+
+    describe 'when environment_exposure is true' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: false,
+          environment_exposure: true,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(50)
+      end
+
+      describe 'when environment_exposure is and maximum_rebar_diameter is greater than 16mm' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: true,
+            structural_element: described_class::STRUCTURAL_ELEMENTS.sample,
+            maximum_rebar_diameter: 17
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(50)
+        end
+      end
+
+      describe 'when environment_exposure is and maximum_rebar_diameter is less than 16mm' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: true,
+            structural_element: described_class::STRUCTURAL_ELEMENTS.sample,
+            maximum_rebar_diameter: (1..16).to_a.sample
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(40)
+        end
+      end
+    end
+
+    describe 'when environment_exposure is false and concrete_casting_against_soil is false' do
+      let(:params) do
+        {
+          concrete_casting_against_soil: false,
+          environment_exposure: false,
+          structural_element: nil,
+          maximum_rebar_diameter: nil
+        }
+      end
+
+      it 'returns the right cover' do
+        expect(result).to eq(50)
+      end
+
+      describe 'when structural_element is one of [slab wall joist]' do
+        describe 'when maximum_rebar_diameter is nil' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: nil
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(40)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter is greater than 36' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: 37
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(40)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter less than 36' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[slab wall joist].sample,
+              maximum_rebar_diameter: (1..36).to_a.sample
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(20)
+          end
+        end
+      end
+
+      describe 'when structural_element is one of [shell thin_shell]' do
+        describe 'when maximum_rebar_diameter is nil' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[shell thin_shell].sample,
+              maximum_rebar_diameter: nil
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(20)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter is greater than 16' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[shell thin_shell].sample,
+              maximum_rebar_diameter: 17
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(20)
+          end
+        end
+
+        describe 'when maximum_rebar_diameter less than 16' do
+          let(:params) do
+            {
+              concrete_casting_against_soil: false,
+              environment_exposure: false,
+              structural_element: %i[shell thin_shell].sample,
+              maximum_rebar_diameter: (1..16).to_a.sample
+            }
+          end
+
+          it 'returns the right cover' do
+            expect(result).to eq(13)
+          end
+        end
+      end
+
+      describe 'when structural_element is one of [beam column]' do
+        let(:params) do
+          {
+            concrete_casting_against_soil: false,
+            environment_exposure: false,
+            structural_element: %i[beam column].sample,
+            maximum_rebar_diameter: nil
+          }
+        end
+
+        it 'returns the right cover' do
+          expect(result).to eq(40)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema_spec.rb
+++ b/spec/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe StructuraidCore::DesignCodes::Schemas::RC::MinimumSteelCoverSchema do
+  describe '.validate!' do
+    subject(:result) { described_class.validate!(params) }
+
+    let(:params) { { concrete_casting_or_exposision_case: 'c.7.7.1.a' } }
+
+    it 'returns true' do
+      expect(result).to eq(true)
+    end
+
+    describe 'when required param is missing' do
+      let(:params) { {} }
+
+      it 'raises an error' do
+        expect { result }.to raise_error(StructuraidCore::DesignCodes::MissingParamError)
+      end
+    end
+  end
+
+  describe '.structurize' do
+    subject(:result) { described_class.structurize(params) }
+
+    let(:params) { { concrete_casting_or_exposision_case: 'c.7.7.1.b' } }
+
+    it 'returns a struct with the required param' do
+      expect(result.concrete_casting_or_exposision_case).to eq('c.7.7.1.b')
+    end
+  end
+end

--- a/spec/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema_spec.rb
+++ b/spec/structuraid_core/design_codes/schemas/rc/minimum_steel_cover_schema_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StructuraidCore::DesignCodes::Schemas::RC::MinimumSteelCoverSchem
   describe '.validate!' do
     subject(:result) { described_class.validate!(params) }
 
-    let(:params) { { concrete_casting_or_exposision_case: 'c.7.7.1.a' } }
+    let(:params) { { concrete_casting_against_soil: true, environment_exposure: false } }
 
     it 'returns true' do
       expect(result).to eq(true)
@@ -22,10 +22,10 @@ RSpec.describe StructuraidCore::DesignCodes::Schemas::RC::MinimumSteelCoverSchem
   describe '.structurize' do
     subject(:result) { described_class.structurize(params) }
 
-    let(:params) { { concrete_casting_or_exposision_case: 'c.7.7.1.b' } }
+    let(:params) { { concrete_casting_against_soil: true, environment_exposure: false } }
 
     it 'returns a struct with the required param' do
-      expect(result.concrete_casting_or_exposision_case).to eq('c.7.7.1.b')
+      expect(result.concrete_casting_against_soil).to eq(true)
     end
   end
 end


### PR DESCRIPTION
closes #21 

NSR-10 and ACI use the same criteria. But:
- NSR groups shell and thin_shell in a category
- ACI groups tensor_joint and pedestal with beam and column

Combinations, and tested cases:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/26731448/234342148-c3643e4e-5620-4aee-a3d0-5040c6e214da.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/26731448/234342295-8f8141c8-a627-486a-b529-dfc1b25877d7.png">
