### PR TITLE
docs(gem-docs): install yard for gem documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,4 @@ Style/IfUnlessModifier:
 
 Layout/LineLength:
   AllowedPatterns: ['\A\s*#'] # Ignore rule for comments
+  

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ AllCops:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-convention:Style/Documentation:
-  Enabled: false
-
 Style/OptionalBooleanParameter:
   Enabled: false
 
@@ -36,3 +33,6 @@ Metrics/ParameterLists:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Layout/LineLength:
+  AllowedPatterns: ['\A\s*#'] # Ignore rule for comments

--- a/lib/structuraid_core/elements/footing.rb
+++ b/lib/structuraid_core/elements/footing.rb
@@ -1,5 +1,6 @@
 module StructuraidCore
   module Elements
+    # A footing is a structural element that transfers load from a column to the soil.
     class Footing < Base
       attr_accessor :length_1, :length_2, :height, :material, :cover_lateral, :cover_top, :cover_bottom
       attr_reader :longitudinal_top_reinforcement_length_1,
@@ -10,6 +11,19 @@ module StructuraidCore
 
       VALID_SECTIONS = %i[length_1 length_2].freeze
 
+      # @param length_1 [Float] The length of the footing in the direction of the main section
+      # @param length_2 [Float] The length of the footing in the direction perpendicular to the main section
+      # @param height [Float] The height of the footing
+      # @param material [Materials::Concrete] The material of the footing. It must be concrete
+      # @param cover_lateral [Float] The lateral cover of the footing
+      # @param cover_top [Float] The top cover of the footing
+      # @param cover_bottom [Float] The bottom cover of the footing
+      # @param longitudinal_top_reinforcement_length_1 [Reinforcement::StraightLongitudinal] The longitudinal reinforcement in the direction of the main section
+      # @param longitudinal_bottom_reinforcement_length_1 [Reinforcement::StraightLongitudinal] The longitudinal reinforcement in the direction of the main section
+      # @param longitudinal_top_reinforcement_length_2 [Reinforcement::StraightLongitudinal] The longitudinal reinforcement in the direction perpendicular to the main section
+      # @param longitudinal_bottom_reinforcement_length_2 [Reinforcement::StraightLongitudinal] The longitudinal reinforcement in the direction perpendicular to the main section
+      #
+      # @return [Footing] the footing
       def initialize(
         length_1:,
         length_2:,
@@ -37,10 +51,16 @@ module StructuraidCore
         @main_section = :length_1
       end
 
+      # Computes the horizontal area of the footing
+      # @return [Float] The horizontal area of the footing
       def horizontal_area
-        @length_1 * @length_2
+        length_1 * length_2
       end
 
+      # Computes the effective height of the footing for each direction and for either top or bottom reinforcement
+      # @param section_direction [Symbol] The direction of the section. See VALID_SECTIONS
+      # @param above_middle [Boolean] Whether the reinforcement is above the middle of the footing
+      # @return [Float] The effective height of the footing
       def effective_height(section_direction:, above_middle:)
         case section_direction
         when :length_1
@@ -50,22 +70,33 @@ module StructuraidCore
         end
       end
 
+      # Sets the coordinates system of the footing
+      # @param coordinates_system [Engineering::Locations::CoordinatesSystem] A coordinates system instance
+      # @return [Engineering::Locations::CoordinatesSystem] The coordinates system of the footing
       def add_coordinates_system(coordinates_system)
         @coordinates_system = coordinates_system
       end
 
+      # Adds a column's location to the footing. If the column's location is already in the footing's coordinates system, it returns the existing location.
+      # @param column_location [Engineering::Locations::Absolute] The column's absolute location
+      # @param column_label [String, Symbol] The column's label
+      # @return [Engineering::Locations::Relative] The column's relative location
       def find_or_add_column_location(column_location, column_label)
         label = "column_#{column_label}"
         relative_location_vector = column_location.to_vector - coordinates_system.anchor_location.to_vector
         coordinates_system.find_or_add_location_from_vector(relative_location_vector, label:)
       end
 
+      # Computes the vertices location of the footing's perimeter horizontally and adds them to the footing's coordinates system
       def add_vertices_location
         vertices_locations_vectors.each do |label, vector|
           coordinates_system.find_or_add_location_from_vector(vector, label:)
         end
       end
 
+      # Evaluates if a relative location is inside the footing's perimeter. It works only for horizontal locations (z = 0)
+      # @param location [Engineering::Locations::Relative] The relative location to evaluate
+      # @return [Boolean] Whether the location is inside the footing's perimeter
       def inside_me?(location)
         inside_axis_2 = location.value_2 >= -0.5 * length_2 && location.value_2 <= 0.5 * length_2
         inside_axis_1 = location.value_1 >= -0.5 * length_1 && location.value_1 <= 0.5 * length_1

--- a/structuraid_core.gemspec
+++ b/structuraid_core.gemspec
@@ -37,10 +37,13 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'byebug', '~> 11.1.3'
   spec.add_development_dependency 'guard-rspec', '~> 4.7.3'
+  spec.add_development_dependency 'puma'
+  spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rubocop', '~> 1.41.1'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.16.0'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'yard'
 
   spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'rake', '~> 13.0.6'


### PR DESCRIPTION
See https://github.com/PradaIng/structuraid-core/wiki/Documentation for an overview on how we will document things from now on.

I documented the `Footing` class to demo how this would work. `yard` will generate a documentation page like this one. There will be a page like this for each abstraction
![screencapture-localhost-8808-docs-StructuraidCore-Elements-Footing-2023-04-30-03_28_03](https://user-images.githubusercontent.com/27536621/235343464-ab789fd6-2d10-47fb-b527-b169f0eae578.png)